### PR TITLE
Next flight is orbital, 250 km, NET August 2021. (#79)

### DIFF
--- a/src/components/blocks/Starship/modelizer.ts
+++ b/src/components/blocks/Starship/modelizer.ts
@@ -27,7 +27,7 @@ const hops: Hop[] = [
   { date: new Date('2021-03-03'), height: 10000 },
   { date: new Date('2021-03-30'), height: 10000 },
   { date: new Date('2021-05-05'), height: 10000 },
-  { date: "May 2021", height: 10000, tentative: true},
+  { date: "NET August 2021", height: 250000, tentative: true},
 ];
 
 const formatHeight = (label: string | number) => {


### PR DESCRIPTION
* Fix typo

* Add SN6 hop.

* Add SN11 hop.

* Add SN15 launch date.

* Fix typo.

* Hop delayed.

* Fix extra ")"

* Fix compilation error.

* SN15 successful, SN16 to launch in two weeks.

* Next launch is orbital, 250 km max height, NET August 2021.